### PR TITLE
Update example to match vars

### DIFF
--- a/examples/main.tf
+++ b/examples/main.tf
@@ -1,7 +1,7 @@
 module "prx_vm" {
   source = "../../modules/terraform-proxmox-vm"
 
-  #count       = "1"
+  #vm_enable       = "1"
   vmid        = "7000"
   name        = "test-vm-1"
   target_node = "proxmox_server"


### PR DESCRIPTION
Changing count to vm_enable in reference to the https://github.com/rkoosaar/terraform-proxmox-vm/blob/e5e0e54d299b3d9e8066bffa6fa18ad887dccfd0/main.tf#L2
it expects var.vm_enable and not count 
tested with both and count is the expected variables for the provider when vm_enable is the expected variable for the module